### PR TITLE
Fix session-start detection for SaveFailingPages listener with non-br…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+* Fix session-start detection for SaveFailingPages listener with a non-browserkit 
+  session : was incorrectly reporting session not started when it should be started.
 * Add PrintDebugTrait as a little BC shorthand for printing stuff from behat 
   contexts.
 * Replace PhantomJSControllerContext with PhantomJSControllerExtension - does

--- a/src/Extension/SaveFailingPagesExtension/SaveFailingPagesListener.php
+++ b/src/Extension/SaveFailingPagesExtension/SaveFailingPagesListener.php
@@ -99,7 +99,7 @@ class SaveFailingPagesListener implements EventSubscriberInterface
             return (bool) $driver->getClient()->getRequest();
         }
 
-        return FALSE;
+        return TRUE;
     }
 
     protected function getOutputFilename(AfterStepTested $event)


### PR DESCRIPTION
…owserkit driver

It was incorrectly reporting selenium sessions as not started, causing no failure
shots / html dumps for javascript sessions.