### PR TITLE
Don't throw fatal if SaveFailingPagesListener given empty file to write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## 0.2.1 (2019-01-31)
+
 * Fix bug where SaveFailingPagesListener threw a fatal exception if asked to write a
   file with no content (e.g. because of a white-page-500 served by the app) masking the
   actual failure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+* Fix bug where SaveFailingPagesListener threw a fatal exception if asked to write a
+  file with no content (e.g. because of a white-page-500 served by the app) masking the
+  actual failure.
+
 ## 0.2.0 (2018-09-18)
 
 * Fix session-start detection for SaveFailingPages listener with a non-browserkit 

--- a/src/Extension/SaveFailingPagesExtension/SaveFailingPagesListener.php
+++ b/src/Extension/SaveFailingPagesExtension/SaveFailingPagesListener.php
@@ -119,6 +119,11 @@ class SaveFailingPagesListener implements EventSubscriberInterface
      */
     protected function writeFile($file, $content)
     {
+        if (empty($content)) {
+            $this->output->writeln('<comment>Warning: No content to write to '.$file.'</comment>');
+            return;
+        }
+
         $path = dirname($file);
         if ( ! is_dir($path)) {
             mkdir($path, 0777, TRUE);


### PR DESCRIPTION
If asked to write a file with no content (e.g. because of a
white-page-500 served by the app) the resultant fatal error (from
file_put_contents returning `0`) masked the actual failure reason.