### PR TITLE
Explicitly start selenium to set the window size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+* Explicitly start selenium to set the window size - fixes bug with latest mink which has
+  (in a minor version) changed the previous behavior that auto-started it on
+  `->getSession()`
+
 ## 1.0.0 (2019-04-03)
 
 * Ensure support for php7.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## 1.0.1 (2020-03-16)
+
 * Explicitly start selenium to set the window size - fixes bug with latest mink which has
   (in a minor version) changed the previous behavior that auto-started it on
   `->getSession()`

--- a/src/Extension/PhantomJSControllerExtension/PhantomJSControllerListener.php
+++ b/src/Extension/PhantomJSControllerExtension/PhantomJSControllerListener.php
@@ -138,10 +138,10 @@ class PhantomJSControllerListener implements EventSubscriberInterface
         }
         $this->output->writeln('<comment>PhantomJS running as process '.$phantom_process->getPid().'</comment>');
 
-        // Set the window size
-        $this->mink
-            ->getSession('selenium2')
-            ->resizeWindow($this->options['window-width'], $this->options['window-height']);
+        // Set the window size - this has to start the session explicitly to do so
+        $selenium = $this->mink->getSession('selenium2');
+        $selenium->start();
+        $selenium->resizeWindow($this->options['window-width'], $this->options['window-height']);
 
         return $phantom_process;
     }


### PR DESCRIPTION
Fixes bug with latest mink which has (in a minor version) changed the
previous behavior that auto-started it on `->getSession()`.