### PR TITLE
Support custom formats for a date placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## 1.4.0 (2024-04-19)
+
+* Support custom formats for a date placeholder e.g. `{{date:Y-m-(d+1) as D}}` for tommorrow's short day of the week
+
 ## 1.3.1 (2024-02-07)
 
 * Advertise existing support for ingenerator/php-utils v2

--- a/docs/scenario_placeholder_extension.md
+++ b/docs/scenario_placeholder_extension.md
@@ -42,9 +42,9 @@ hardcoded values.
 
 Out of the box, we support:
 
-| type | description                                                                                                           |
-|------|-----------------------------------------------------------------------------------------------------------------------|
-| date | Passes the argument through `Ingenerator\BehatSupport\Param\DateParam::parse()` and returns a date formatted as Y-m-d |
+| type | description                                                                                                                                                                                                              |
+|------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| date | Passes the argument through `Ingenerator\BehatSupport\Param\DateParam::parse()` and returns a date. By default this will be formatted Y-m-d, but you can specify a custom format with e.g. `{{date:Y-m-(d+1) as j M Y}}` |
 
 ### Registering custom placeholders
 

--- a/src/Extension/ScenarioPlaceholderExtension/ScenarioPlaceholderManager.php
+++ b/src/Extension/ScenarioPlaceholderExtension/ScenarioPlaceholderManager.php
@@ -92,6 +92,13 @@ class ScenarioPlaceholderManager implements EventSubscriberInterface
 
     private function transformDate(string $arg): string
     {
-        return DateParam::parse($arg)->format('Y-m-d');
+        // Parse a string like either:
+        // - `2024-m-d` (or any value parseable as a DateParam) for the date formatted as Y-m-d
+        // - `Y-m-d as d M Y` to have the parsed value with a custom date format
+        $arg_parts = explode(' as ', $arg);
+        // If no format specified, use Y-m-d by default
+        $arg_parts[1] ??= 'Y-m-d';
+
+        return DateParam::parse($arg_parts[0])->format($arg_parts[1]);
     }
 }

--- a/test/Extension/ScenarioPlaceholderExtension/ScenarioPlaceholderManagerTest.php
+++ b/test/Extension/ScenarioPlaceholderExtension/ScenarioPlaceholderManagerTest.php
@@ -23,6 +23,7 @@ class ScenarioPlaceholderManagerTest extends TestCase
         return [
             'tomorrow'  => ['Y-m-(d+1)', (new \DateTimeImmutable('tomorrow'))->format('Y-m-d')],
             'next year' => ['(Y+1)-03-02', (date('Y') + 1).'-03-02'],
+            'custom format' => ['(Y+1)-03-02 as j M y', '2 Mar '.(date('y') + 1)],
         ];
     }
 


### PR DESCRIPTION
For example `{{date:Y-m-(d+1) as D}}` for tommorrow formatted as the short day of the week name.