### PR TITLE
Remove direct dependency on PHPUnit, use `sebastian/diff` instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 * Support PHP 8.3
-* Support PHPUnit^10
+* Remove direct dependency on PHPUnit - instead uses `sebastian/diff` direct to produce pretty assertion failures from 
+  SimpleApiEmulatorContext. This allows the package to be installed alongside a wider range of PHPUnit versions in
+  consuming projects.
 
 ## 1.4.0 (2024-04-19)
 

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,11 @@
     "behat/behat": "^3.11",
     "ext-json": "*",
     "symfony/http-client": "^5.4 || ^6.3",
-    "phpunit/phpunit": "^10.5",
-    "ingenerator/php-utils": "^1.19 || ^2.0"
+    "ingenerator/php-utils": "^1.19 || ^2.0",
+    "sebastian/diff": "^5.1"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^10.5"
   },
   "support": {
     "source": "https://github.com/ingenerator/behat-support/",

--- a/src/Extension/ApiEmulatorExtension/SimpleApiEmulatorContext.php
+++ b/src/Extension/ApiEmulatorExtension/SimpleApiEmulatorContext.php
@@ -4,11 +4,14 @@ namespace Ingenerator\BehatSupport\Extension\ApiEmulatorExtension;
 
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\PyStringNode;
-use PHPUnit\Framework\Assert;
-use PHPUnit\Framework\ExpectationFailedException;
-use function json_decode;
+use Ingenerator\PHPUtils\StringEncoding\JSON;
+use SebastianBergmann\Diff\Differ;
+use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
+use function json_encode;
 use function sprintf;
 use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_PRETTY_PRINT;
 
 class SimpleApiEmulatorContext implements Context, ApiEmulatorAwareContext
 {
@@ -34,19 +37,25 @@ class SimpleApiEmulatorContext implements Context, ApiEmulatorAwareContext
     {
         $request = $this->client->listRequests()->assertSingleRequestTo($method, $url);
 
-        $expected = json_decode($expected_body->getRaw(), associative: true, flags: JSON_THROW_ON_ERROR);
+        $expected = JSON::decode($expected_body->getRaw());
 
-        try {
-            Assert::assertSame($expected, $request->parsed_body,);
-        } catch (ExpectationFailedException $e) {
-            throw new ApiEmulatorAssertionFailedException(
-                sprintf(
-                    "Payload of %s to %s did not match expectation:\n%s",
-                    $method,
-                    $url,
-                    trim($e->getComparisonFailure()?->getDiff() ?? $e->getMessage())
-                )
-            );
+        if ($request->parsed_body === $expected) {
+            return;
         }
+
+        $diff = (new Differ(new UnifiedDiffOutputBuilder("\n--- Expected\n+++ Actual\n")))
+            ->diff(
+                json_encode($expected, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR),
+                json_encode($request->parsed_body, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)
+            );
+
+        throw new ApiEmulatorAssertionFailedException(
+            sprintf(
+                "Payload of %s to %s did not match expectation:\n%s",
+                $method,
+                $url,
+                trim($diff)
+            )
+        );
     }
 }

--- a/test/Extension/ApiEmulatorExtension/SimpleApiEmulatorContextTest.php
+++ b/test/Extension/ApiEmulatorExtension/SimpleApiEmulatorContextTest.php
@@ -102,12 +102,12 @@ class SimpleApiEmulatorContextTest extends TestCase
                     --- Expected
                     +++ Actual
                     @@ @@
-                     Array &0 [
-                         'some' => Array &1 [
-                    -        'nested' => 'data',
-                    +        'noosted' => 'data',
-                         ],
-                     ]
+                     {
+                         "some": {
+                    -        "nested": "data"
+                    +        "noosted": "data"
+                         }
+                     }
                     TEXT,
             ],
             'passes with correct request and body' => [


### PR DESCRIPTION
As noted on Slack, we can theoretically support a wide range of `sebastian/diff`, although his versioning unfortunately means we can't explicitly test that they definitely all work (e.g. are type-safe with our code). 

Since the code is only used to render an assertion failure (and therefore in theory can't be triggered in a project's test suite that is currently green), I think this is an acceptable compromise for the win of being installable alongside a wider phpunit version range...