### PR TITLE
Expand supported range of sebastian/diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## 1.4.2 (2024-08-13)
+* Support `sebastian/diff` 4, 5, and 6 to allow use alongside PHPUnit 9 - 11.
+
 ## 1.4.1 (2024-08-07)
 
 * Support PHP 8.3

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "ext-json": "*",
     "symfony/http-client": "^5.4 || ^6.3",
     "ingenerator/php-utils": "^1.19 || ^2.0",
-    "sebastian/diff": "^5.1"
+    "sebastian/diff": "^4.0||^5.1||^6.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5"


### PR DESCRIPTION
I could have sworn this was what I did in #28 but it seems I committed a tight constraint - so the package still can't be upgraded if you have phpunit != 10 in a project.

See #28 for the rationale for supporting this wide version range even though we can only test it with one version.